### PR TITLE
Switch to Kafka and ZK images from Confluent Inc

### DIFF
--- a/dh-rdbms-k8s/kafka-zk-ephemeral.yaml
+++ b/dh-rdbms-k8s/kafka-zk-ephemeral.yaml
@@ -23,10 +23,10 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: wurstmeister/zookeeper
+        image: confluentinc/cp-zookeeper:3.2.2
         env:
-        - name: JAVA_TOOL_OPTIONS
-          value: "-Xmx1024m"
+        - name: ZOOKEEPER_CLIENT_PORT
+          value: "2181"
         ports:
         - name: zk-client
           containerPort: 2181
@@ -66,20 +66,12 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: devicehive/devicehive-kafka
+        image: confluentinc/cp-kafka:3.2.2
         env:
-        - name: KAFKA_ADVERTISED_PORT
-          value: "9092"
-        - name: KAFKA_ADVERTISED_HOST_NAME
-          value: "kafka-kf"
-        - name: KAFKA_ADVERTISED_LISTENERS
-          value: "PLAINTEXT://kafka-kf:9092"
         - name: KAFKA_ZOOKEEPER_CONNECT
-          value: "kafka-zookeeper-zk:2181"
-        - name: DH_ZK_ADDRESS
-          value: "kafka-zookeeper-zk"
-        - name: DH_ZK_PORT
-          value: "2181"
+          value: kafka-zookeeper-zk:2181
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka-kf:9092
         ports:
         - name: kafka
           containerPort: 9092

--- a/rdbms-image/docker-compose.yml
+++ b/rdbms-image/docker-compose.yml
@@ -1,23 +1,21 @@
 version: "3"
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: confluentinc/cp-zookeeper:3.2.2
     ports:
       - "2181:2181"
     environment:
-      JAVA_TOOL_OPTIONS: "-Xmx1024m"
+      ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka:
-    image: devicehive/devicehive-kafka
+    image: confluentinc/cp-kafka:3.2.2
     ports:
       - "9092:9092"
     links:
       - "zookeeper"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_PORT: 9092
-      DH_ZK_ADDRESS: zookeeper
-      DH_ZK_PORT: 2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
 
   postgres:
     image: postgres:9.4

--- a/riak-image/docker-compose.yml
+++ b/riak-image/docker-compose.yml
@@ -1,23 +1,21 @@
 version: "3"
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: confluentinc/cp-zookeeper:3.2.2
     ports:
       - "2181:2181"
     environment:
-      JAVA_TOOL_OPTIONS: "-Xmx1024m"
+      ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka:
-    image: devicehive/devicehive-kafka
+    image: confluentinc/cp-kafka:3.2.2
     ports:
       - "9092:9092"
     links:
       - "zookeeper"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_PORT: 9092
-      DH_ZK_ADDRESS: zookeeper
-      DH_ZK_PORT: 2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
  
   coordinator:
     image: devicehive/devicehive-riakts


### PR DESCRIPTION
This is official images from Kafka supporting company.
Java memory parameters are dropped for now because Confluent images may
provide another way for doing this.